### PR TITLE
chore: enforce branch-first workflow in CLAUDE.md and skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -283,6 +283,16 @@ building it in from the start.
 - **Never force-push to `master`** — branch protection blocks this
 - **Branch naming**: `type/short-description` (e.g., `feature/locale-switcher`, `fix/login-timeout`)
   - Types: `feature/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`
+- **Mandatory branch creation**: Before ANY code change (feature, bugfix, refactor, etc.), Claude
+  MUST create a new branch from `master` using the naming convention above. No work on `master`.
+  - Features: `feature/{task-id}-{short-name}` (e.g., `feature/task-030-smart-resume-reuse-m1`)
+  - Bugfixes: `fix/{issue-or-description}` (e.g., `fix/mypy-type-error-experience-calc`)
+  - Refactors: `refactor/{short-name}` (e.g., `refactor/extract-db-helpers`)
+  - Docs: `docs/{short-name}` (e.g., `docs/update-readme-test-count`)
+  - Tests: `test/{short-name}` (e.g., `test/add-kb-integration-tests`)
+  - Chores: `chore/{short-name}` (e.g., `chore/update-dependencies`)
+- **Branch lifecycle**: Create branch → commit changes → push → open PR → CI green → squash-merge → delete branch
+- **One branch per task**: Each TASK-NNN or bugfix gets its own branch. Never reuse branches across unrelated tasks.
 
 ### 9.2 Commit Messages
 ```
@@ -315,8 +325,10 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 | Large  | 300+        | Break into smaller PRs when possible |
 
 ### 9.5 Before Opening a PR
-1. Create branch from `master` using naming convention
-2. Run locally: `ruff check .` (lint) + `python -m pytest tests/ -v` (tests)
+1. **Branch** (must be done FIRST, before any code changes):
+   - `git checkout master && git pull origin master`
+   - `git checkout -b type/short-description` (see §9.1 naming convention)
+2. Run locally: `ruff check .` (lint) + `mypy` (type check) + `python -m pytest tests/ -v` (tests)
 3. Update `CHANGELOG.md` under `[Unreleased]` if user-facing
 4. Update `docs/` and `README.md` if features/test count changed
 
@@ -411,3 +423,13 @@ Patterns confirmed during delivery. Apply to all future work.
 - Close the issue with `gh issue close N --comment "Completed in commit <hash>."` when pushed.
 - If an existing open issue matches the task being implemented, use that issue instead of creating a duplicate.
 - **Rule**: The Release Engineer checklist includes "GitHub Issue closed" — a task is NOT done until the issue is closed.
+
+### 12.9 Branch-First Workflow
+- Always create a new branch from `master` BEFORE writing any code. Never start work on `master`
+  or on an existing branch belonging to a different task.
+- Branch names MUST indicate the type of work: `feature/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`.
+  This makes it immediately clear from the branch name what kind of change to expect.
+- Include the TASK-ID in feature branch names (e.g., `feature/task-030-smart-resume-reuse-m1`)
+  so branches are traceable to their GitHub issue and planning artifacts.
+- One branch = one PR = one logical change. Don't pile unrelated changes into one branch.
+- After PR is merged, delete the remote branch to keep the repo clean.

--- a/.claude/skills/role-backend-developer/SKILL.md
+++ b/.claude/skills/role-backend-developer/SKILL.md
@@ -34,7 +34,12 @@ Before writing any code:
 - [ ] Examine existing codebase — match conventions, patterns, naming.
 - [ ] Verify project structure and build configuration work.
 - [ ] Pin all new dependency versions explicitly.
-- [ ] Create branch following git conventions: `feature/{task-id}-{short-name}`.
+- [ ] **Create branch FIRST** (before any code changes):
+  - `git checkout master && git pull origin master`
+  - Features: `git checkout -b feature/{task-id}-{short-name}`
+  - Bugfixes: `git checkout -b fix/{issue-or-description}`
+  - Refactors: `git checkout -b refactor/{short-name}`
+  - Never work directly on `master`. One branch per task.
 
 ---
 

--- a/.claude/skills/role-project-manager/SKILL.md
+++ b/.claude/skills/role-project-manager/SKILL.md
@@ -80,8 +80,9 @@ Upon receiving a task, classify and activate the right roles:
 
 | # | Phase | Role(s) | Deliverable | Size | Depends On | Status |
 |---|-------|---------|-------------|------|------------|--------|
-| 0 | GitHub Issue | PjM | `gh issue create` with title + labels | S | — | ⬜ |
-| 1 | Program alignment | PgM | Alignment confirmation | S | 0 | ⬜ |
+| 0a| GitHub Issue | PjM | `gh issue create` with title + labels | S | — | ⬜ |
+| 0b| **Create branch** | PjM | `git checkout -b type/task-id-short-name` from master | S | 0a | ⬜ |
+| 1 | Program alignment | PgM | Alignment confirmation | S | 0b | ⬜ |
 | 2 | Project planning | PjM | This plan + role activation | S | 1 | ⬜ |
 | 3 | Product vision | PM | PRD + user stories | S-M | 2 | ⬜ |
 | 4 | Requirements | RA | SRS document | M | 3 | ⬜ |
@@ -92,7 +93,12 @@ Upon receiving a task, classify and activate the right roles:
 | 9 | Integration test | IT | E2E + perf tests | M | 8 | ⬜ |
 | 10| Security audit | SecE | Audit report | S-M | 8 | ⬜ |
 | 11| Documentation | Doc | All docs | S-M | 6,7,8 | ⬜ |
-| 12| Release | RE | Release package | S | 9,10,11 | ⬜ |
+| 12| Release | RE | Push, PR, merge, delete branch | S | 9,10,11 | ⬜ |
+
+**Branch naming** (Phase 0b):
+- Features: `feature/task-{NNN}-{short-name}` (e.g., `feature/task-030-smart-resume-reuse-m1`)
+- Bugfixes: `fix/{issue-or-description}` (e.g., `fix/mypy-type-error-experience-calc`)
+- Refactors: `refactor/{short-name}` | Docs: `docs/{short-name}` | Tests: `test/{short-name}` | Chores: `chore/{short-name}`
 ```
 
 ---

--- a/.claude/skills/role-release-engineer/SKILL.md
+++ b/.claude/skills/role-release-engineer/SKILL.md
@@ -151,11 +151,15 @@ Requirements ✅ | Design ✅ | Review ✅ | Security ✅ | Docs ✅ | Traceabil
 
 When creating PRs for releases or feature delivery:
 
-1. **Branch**: Create from `master` using `type/short-description` convention
+1. **Branch** (MANDATORY — before any code changes):
+   - `git checkout master && git pull origin master`
+   - `git checkout -b type/short-description` (e.g., `feature/task-030-kb-foundation`, `fix/mypy-type-error`)
+   - Types: `feature/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`
+   - Include TASK-ID in feature branches for traceability
 2. **Commits**: Use conventional format (`feat:`, `fix:`, `chore:`, etc.)
 3. **PR**: Use `gh pr create` with Summary, Changes, Test plan sections
 4. **CI**: Ensure all 3 checks pass (lint, test, security) before merge
-5. **Merge**: Squash-merge to `master`, delete branch after merge
+5. **Merge**: Squash-merge to `master`, delete remote branch after merge
 6. **Tag**: For releases, create `v{semver}` tag to trigger release workflow
 7. **Release notes**: Use `gh release create` with changelog summary
 

--- a/.claude/skills/role-release-engineer/references/cicd-patterns.md
+++ b/.claude/skills/role-release-engineer/references/cicd-patterns.md
@@ -59,24 +59,35 @@ ENTRYPOINT ["node", "/app/index.js"]
 ### Branch Strategy
 ```
 master (protected) ← PR only, squash-merge
-  ├── feature/locale-switcher
-  ├── fix/login-timeout
-  ├── refactor/split-bot-loop
-  ├── docs/update-api-reference
-  ├── test/applier-edge-cases
-  └── chore/upgrade-playwright
+  ├── feature/task-030-smart-resume-reuse-m1   ← new feature (with TASK-ID)
+  ├── feature/task-031-tfidf-scoring           ← new feature (with TASK-ID)
+  ├── fix/mypy-type-error-experience-calc      ← bugfix (descriptive name)
+  ├── fix/ci-lint-failure                      ← bugfix
+  ├── refactor/split-bot-loop                  ← code refactor
+  ├── docs/update-api-reference                ← documentation only
+  ├── test/applier-edge-cases                  ← test additions
+  └── chore/upgrade-playwright                 ← maintenance
+
+Branch naming rules:
+  - MUST start with type prefix: feature/, fix/, refactor/, docs/, test/, chore/
+  - feature/ branches MUST include TASK-ID for traceability
+  - fix/ branches should reference the issue or describe the bug
+  - Use kebab-case (lowercase, hyphens)
+  - Keep names short but descriptive (3-6 words after prefix)
 ```
 
-### PR Lifecycle
+### PR Lifecycle (MANDATORY — every code change follows this)
 ```
-1. Create branch: git checkout -b type/short-description
-2. Develop + test locally: ruff check . && python -m pytest tests/ -v
+1. Create branch FIRST (before any code changes):
+   git checkout master && git pull origin master
+   git checkout -b type/short-description
+2. Develop + test locally: ruff check . && mypy && python -m pytest tests/ -v
 3. Push: git push -u origin type/short-description
 4. Open PR: gh pr create --title "..." --body "..."
 5. CI runs: lint → test → security (all 3 must pass)
 6. Review: address feedback with new commits (no force-push)
 7. Merge: squash-merge to master
-8. Cleanup: delete remote branch
+8. Cleanup: delete remote branch (gh pr merge --delete-branch)
 ```
 
 ### PR Template Sections


### PR DESCRIPTION
## Summary
- Makes branch creation **mandatory** before any code changes across the engineering framework
- Adds naming conventions by change type: `feature/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`
- Feature branches must include TASK-ID for traceability (e.g., `feature/task-030-kb-foundation`)

## Changes
- **CLAUDE.md §9.1**: Mandatory branch creation rules with full naming convention
- **CLAUDE.md §9.5**: Branch creation as explicit step 1 in PR checklist
- **CLAUDE.md §12.9**: New lesson learned — branch-first workflow
- **role-backend-developer/SKILL.md**: Expanded branch creation in pre-build checklist
- **role-project-manager/SKILL.md**: Added Phase 0b (create branch) to WBS template
- **role-release-engineer/SKILL.md**: Expanded PR lifecycle step 1
- **cicd-patterns.md**: Updated branch strategy with examples and naming rules

## Test plan
- [x] No code changes — docs/config only
- [x] All conventions consistent across CLAUDE.md, 3 skill files, and 1 reference file


🤖 Generated with [Claude Code](https://claude.com/claude-code)