### PR TITLE
refactor: upgrade governance framework to CLAUDE.md v5.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,14 @@
-# Enterprise Engineering Framework — CLAUDE.md v4.2
+# Enterprise Engineering Framework — CLAUDE.md v5.0
 
 > **Supreme Governance Document**
 > Claude MUST read this file completely before taking any action.
 > This defines a full engineering organization with 16 specialized roles.
 > Each role has deep expertise, operating procedures, intake/output contracts,
 > checklists, templates, and escalation paths. Claude assumes each role in sequence.
+>
+> **Shared Workflows**: Branch lifecycle, GitHub issue lifecycle, PR checklist,
+> scope determination, and traceability rules are defined in
+> `references/shared-workflows.md` — the **single source of truth**.
 
 ---
 
@@ -84,7 +88,9 @@ Every task flows through these phases in order. Roles activate per phase.
 
 | Phase | Name                        | Primary Role(s)                         | Skill File                              | Gate Output                          |
 |-------|-----------------------------|-----------------------------------------|-----------------------------------------|--------------------------------------|
-| 0     | Program Alignment           | Program Manager                         | `role-program-manager/SKILL.md`         | Strategic alignment confirmation     |
+| 0a    | GitHub Issue                | Project Manager                         | `role-project-manager/SKILL.md`         | Issue created with labels + AC       |
+| 0b    | Branch Creation             | Project Manager                         | `references/shared-workflows.md` §1     | Branch created from clean `master`   |
+| 0c    | Program Alignment           | Program Manager                         | `role-program-manager/SKILL.md`         | Strategic alignment confirmation     |
 | 1     | Project Planning            | Project Manager                         | `role-project-manager/SKILL.md`         | Project plan, WBS, schedule          |
 | 2     | Product Vision              | Product Manager                         | `role-product-manager/SKILL.md`         | PRD, user stories, prioritization    |
 | 3     | Requirements Analysis       | Requirements Analyst                    | `role-requirements-analyst/SKILL.md`    | SRS document, traceability seeds     |
@@ -103,32 +109,33 @@ Every task flows through these phases in order. Roles activate per phase.
 ### Adaptive Activation
 
 Not every role activates on every task. The **Project Manager** (Phase 1) determines
-which roles are needed based on task classification:
+which roles are needed based on task classification.
+See `references/shared-workflows.md` §4 for the scope determination decision tree
+and role activation table.
 
 | Task Type            | Roles Activated (minimum)                                                |
 |----------------------|--------------------------------------------------------------------------|
-| Backend feature      | 7,8,9,10 → 1 → 3 → 4 → 5 → 10 → 11 → 13 → 12 → 14                    |
-| Frontend feature     | 7,8,9,10 → 1 → 3 → 4 → 6 → 10 → 11 → 13 → 12 → 14                    |
-| Full-stack feature   | 7,8,9,10 → 1 → 3 → 4 → 5+6 → 10 → 11 → 13 → 12 → 14                  |
-| Data pipeline        | 7,8,9,10 → 1 → 3 → 4 → 7 → 10 → 11 → 13 → 12 → 14                    |
-| ML feature           | 7,8,9,10 → 1 → 3 → 4 → 8+9 → 10 → 11 → 13 → 12 → 14                  |
-| AWS infrastructure   | 7,8,9,10 → 1 → 3 → 2+4 → 13 → 12 → 14                                 |
-| Bugfix (small)       | 10 → 3(inline) → 5 or 6 → 10 → 13(inline) → 12(inline)                 |
-| Documentation only   | 10 → 13 → 14(inline)                                                    |
-| Spike/research       | 10 → 3(inline) → relevant build role → 13(inline)                       |
-
-Legend: Numbers reference role numbers from the org chart.
+| Backend feature      | PgM, PjM, PM, RA → SE → BE → UT → IT → SecE → Doc → RE                |
+| Frontend feature     | PgM, PjM, PM, RA → SE → FE → UT → IT → SecE → Doc → RE                |
+| Full-stack feature   | PgM, PjM, PM, RA → SE → BE+FE → UT → IT → SecE → Doc → RE             |
+| Data pipeline        | PgM, PjM, PM, RA → SE → DE → UT → IT → SecE → Doc → RE                |
+| ML feature           | PgM, PjM, PM, RA → SE → DS+MLE → UT → IT → SecE → Doc → RE            |
+| AWS infrastructure   | PgM, PjM, PM, RA → SE+AWS → SecE → Doc → RE                            |
+| Bugfix (small)       | PjM(inline) → BE or FE → UT → Doc(inline) → RE(inline)                  |
+| Documentation only   | PjM(inline) → Doc → RE(inline)                                          |
+| Spike/research       | PjM(inline) → relevant build role → Doc(inline)                         |
 
 ### Quality Gates
 
 ```
-Phase 0    Phase 1      Phase 2      Phase 3       Phase 4
-Program ──▶ Project ──▶ Product  ──▶ Require-  ──▶ System
-Align       Plan         Vision       ments         Design
+Phase 0a   Phase 0b     Phase 0c     Phase 1      Phase 2
+GitHub ──▶ Branch   ──▶ Program  ──▶ Project  ──▶ Product
+Issue       Create       Align        Plan         Vision
   │           │            │            │              │
   ▼           ▼            ▼            ▼              ▼
-Phase 5-9 (BUILD — parallel where independent)
-Backend ──▶ Frontend ──▶ Data Eng ──▶ Data Sci ──▶ ML Eng
+Phase 3      Phase 4      Phase 5-9 (BUILD — parallel where independent)
+Require- ──▶ System   ──▶ Backend ──▶ Frontend ──▶ Data/ML
+ments        Design
   │           │            │            │              │
   ▼           ▼            ▼            ▼              ▼
 Phase 10     Phase 11     Phase 12     Phase 13     Phase 14
@@ -140,19 +147,22 @@ Test         Test         Audit        ation         Package
 
 ## 3. NON-NEGOTIABLE PRINCIPLES
 
-1. **Requirements before design** — No system design without approved SRS.
-2. **Design before code** — No implementation without approved architecture.
-3. **Tests before merge** — No delivery without unit AND integration tests.
-4. **Security before release** — No release without security audit pass.
-5. **Docs before handoff** — No release without complete documentation.
-6. **Traceability always** — Every artifact links requirement → design → code → test → doc.
-7. **No silent assumptions** — Every ambiguity resolved, every assumption documented.
-8. **Production-readiness built in** — Security, i18n, a11y, logging, resilience are requirements of the Build phase (§8), not afterthoughts. Every new endpoint uses `t()`, every new UI element has ARIA, every external call has retry+timeout.
-9. **GitHub Issues for every implementation** — Every task (TASK-NNN) MUST have a corresponding GitHub issue. Create the issue at the START of implementation (Phase 1/2), update it during build with progress notes, and close it with a completion comment referencing the commit hash when pushed. Use `gh issue create` and `gh issue close` via CLI.
+1. **Branch before work** — Create a named branch from clean `master` BEFORE any code changes. See `references/shared-workflows.md` §1.
+2. **Requirements before design** — No system design without approved SRS.
+3. **Design before code** — No implementation without approved architecture.
+4. **Tests before merge** — No delivery without unit AND integration tests.
+5. **Security before release** — No release without security audit pass.
+6. **Docs before handoff** — No release without complete documentation.
+7. **Traceability always** — Every artifact links requirement → design → code → test → doc.
+8. **No silent assumptions** — Every ambiguity resolved, every assumption documented.
+9. **Production-readiness built in** — Security, i18n, a11y, logging, resilience are requirements of the Build phase (§8), not afterthoughts.
+10. **GitHub Issues for every implementation** — Every task (TASK-NNN) MUST have a corresponding GitHub issue. See `references/shared-workflows.md` §2.
 
 ---
 
 ## 4. SCOPE SCALING
+
+See `references/shared-workflows.md` §4 for the decision tree.
 
 | Scope   | LOC    | Leadership  | Design    | Build | Test     | Quality    | Release   |
 |---------|--------|-------------|-----------|-------|----------|------------|-----------|
@@ -164,7 +174,7 @@ Test         Test         Audit        ation         Package
 
 ## 5. TRACEABILITY MATRIX
 
-Every delivery MUST include:
+Every delivery MUST include. See `references/shared-workflows.md` §5 for rules.
 
 ```
 | Req ID  | User Story | Design Ref   | Source Files  | Unit Tests   | Integ Tests  | Docs        | Security | Status |
@@ -249,7 +259,7 @@ building it in from the start.
 - [ ] Reduced motion: `@media (prefers-reduced-motion: reduce)` disables animations
 
 ### 8.6 Testing (every deliverable)
-- [ ] Unit tests for all new functions (target >80% line coverage)
+- [ ] Unit tests for all new functions (target >=90% line, >=85% branch coverage)
 - [ ] Integration tests for API endpoints (request → response contract)
 - [ ] Thread safety tests for shared mutable state
 - [ ] Use `tmp_path` fixtures — never pollute real data directories
@@ -277,12 +287,15 @@ building it in from the start.
 
 ## 9. GITHUB REPOSITORY & PR RULES
 
+> **Canonical rules** for branch lifecycle, issue lifecycle, and PR checklists
+> are in `references/shared-workflows.md`. This section summarizes; defer to that
+> file on any conflict.
+
 ### 9.1 Repository Conventions
 - **Main branch**: `master` — protected with 3 required CI checks (lint, test, security)
 - **Never push directly to `master`** — always use a PR
 - **Never force-push to `master`** — branch protection blocks this
-- **Branch naming**: `type/short-description` (e.g., `feature/locale-switcher`, `fix/login-timeout`)
-  - Types: `feature/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`
+- **Branch naming**: `type/short-description` — see `references/shared-workflows.md` §1
 
 ### 9.2 Commit Messages
 ```
@@ -297,35 +310,18 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 - Reference issues in body when applicable (`Closes #42`)
 
 ### 9.3 Pull Request Rules
+- See `references/shared-workflows.md` §3 for the full checklist.
 - **One feature or fix per PR** — keep changes focused
-- **Title**: Under 72 characters, describes the change
-- **Description**: Must include Summary, Changes, Test plan (use PR template)
 - **CI must be green**: All 3 checks (lint, test, security) must pass before merge
-- **Branch must be current** with `master` before merge
-- **Tests required**: New code must have corresponding tests
-- **No secrets**: Never commit API keys, tokens, `.env`, or `config.json` with real data
-- **Review**: Address all review feedback with new commits (don't force-push during review)
-- **Merge strategy**: Squash-merge to `master`
+- **Coverage target**: >=90% line, >=85% branch for new code
+- **Merge strategy**: Squash-merge to `master`, delete branch after merge
 
-### 9.4 PR Size Guidelines
-| Size   | LOC Changed | Expectation |
-|--------|-------------|-------------|
-| Small  | < 50        | Quick review, merge same day |
-| Medium | 50–300      | Detailed review, may need revisions |
-| Large  | 300+        | Break into smaller PRs when possible |
-
-### 9.5 Before Opening a PR
-1. Create branch from `master` using naming convention
-2. Run locally: `ruff check .` (lint) + `python -m pytest tests/ -v` (tests)
-3. Update `CHANGELOG.md` under `[Unreleased]` if user-facing
-4. Update `docs/` and `README.md` if features/test count changed
-
-### 9.6 GitHub Workflows
+### 9.4 GitHub Workflows
 - **CI** (`.github/workflows/ci.yml`): Runs on every push/PR — lint, test, security
 - **Release** (`.github/workflows/release.yml`): Runs on `v*` tag push — builds Windows/macOS/Linux installers, uploads to GitHub Releases
 - **Dependabot** (`.github/dependabot.yml`): Automated dependency update PRs
 
-### 9.7 Issue Templates
+### 9.5 Issue Templates & CODEOWNERS
 - **Bug reports**: `.github/ISSUE_TEMPLATE/bug_report.md` — OS, Python version, logs
 - **Feature requests**: `.github/ISSUE_TEMPLATE/feature_request.md` — describe problem first
 - **CODEOWNERS**: `@AbhishekMandapmalvi` auto-assigned on all PRs
@@ -351,63 +347,31 @@ After every task: what went well, what to improve, patterns to capture.
 
 Patterns confirmed during delivery. Apply to all future work.
 
-### 12.1 API Contract Alignment
+### 12.1 API & Data Contract Alignment
 - Define field names in SAD interface contracts BEFORE any frontend work.
-- Frontend and backend MUST use identical field names (e.g., `full_name` not `name`,
-  `search_criteria` not `preferences`). Mismatches cause cascading fixes.
-- Run a contract check between SAD field names and frontend code before integration.
-
-### 12.2 Flask Route Ordering
-- Place static routes BEFORE parameterized routes (`/api/x/export` before `/api/x/<id>`).
-- Flask matches routes top-down; a parameterized route can shadow a static sibling.
-
-### 12.3 Pydantic Model Serialization
-- Pydantic models are NOT directly JSON-serializable by Flask's `jsonify`.
-- Always call `.model_dump()` before passing to `jsonify`.
+- Frontend and backend MUST use identical field names. Mismatches cause cascading fixes.
+- Pydantic models are NOT directly JSON-serializable by Flask's `jsonify` — call `.model_dump()` first.
 - Use attribute access (`obj.field`), not dict access (`obj["field"]`), on Pydantic models.
 
-### 12.4 Security Checks During Build
-- Add path traversal protection (allowlist regex) on ANY endpoint accepting filenames.
-- Add global error handlers early — unhandled exceptions leak stack traces as HTML.
+### 12.2 Flask Specifics
+- Place static routes BEFORE parameterized routes (`/api/x/export` before `/api/x/<id>`).
 - Bind to `127.0.0.1`, never `0.0.0.0`, for local-only applications.
 
-### 12.5 Testing Insights
+### 12.3 Testing Insights
 - Thread safety tests should use multiple threads with high iteration counts (10 x 1000).
 - Integration tests catch field name mismatches that unit tests miss — run them early.
 - Use `tmp_path` fixtures for filesystem tests to avoid polluting real data directories.
 - Exit code 15 on Windows with gevent is a signal handling quirk, not a test failure.
 
-### 12.6 Electron + Python Integration
+### 12.4 Electron + Python Integration
 - `python-backend.js` must check for a local venv (`venv/Scripts/python.exe`) before system Python.
-  Otherwise the spawned process gets `ModuleNotFoundError` because system Python lacks Flask.
-- Electron's `app.isPackaged` is undefined outside Electron context — guard with
-  `app && typeof app.isPackaged !== 'undefined'` when modules are also imported by Node directly.
-- Use `windowsHide: true` in `child_process.spawn()` to prevent a console window flash on Windows.
-- For graceful shutdown on Windows, use `taskkill /PID /T /F` instead of `SIGTERM` (not supported).
-- Separate Chromium: Playwright needs its own Chromium (`playwright install chromium`).
-  Electron's bundled Chromium cannot be reused because Playwright requires persistent browser
-  contexts with a custom user data directory, which is incompatible with Electron's embedded binary.
-  The original shared-Chromium strategy (ADR-006) was abandoned after discovering this limitation.
+- Guard `app.isPackaged` with `app && typeof app.isPackaged !== 'undefined'` for dual-context modules.
+- Use `windowsHide: true` in `child_process.spawn()` to prevent console flash on Windows.
+- For graceful shutdown on Windows, use `taskkill /PID /T /F` instead of `SIGTERM`.
+- Playwright needs its own Chromium (`playwright install chromium`) — Electron's bundled Chromium cannot be reused for persistent browser contexts.
 
-### 12.7 Production-Readiness Is Not a Phase
-- Retrofitting i18n into 460+ hardcoded strings across 7 route files, 19 JS modules, and 1 HTML
-  template cost an entire session. Had `t()` been used from the first endpoint, it would have been
-  free — just a different function call for the same string.
-- Same for accessibility: adding ARIA to 50+ elements, keyboard navigation to 5 components, and
-  focus traps to 4 modals after the fact required re-reading every file. Building it in means
-  writing `<button>` instead of `<span onclick>` — zero extra effort.
-- SQLite WAL mode is a 2-line PRAGMA. Retry with backoff is a 30-line wrapper. Both should be
-  in the first commit, not discovered after production issues.
-- Security headers, auth middleware, rate limiting, and error handlers should be in `create_app()`
-  from the very first endpoint. Adding them later means auditing every existing route.
-- **Rule**: Section 8 checklist items are requirements for Phase 5-6 (Build), not Phase 12 (Security Audit).
-  The Security Audit confirms they were done, not does them for the first time.
-
-### 12.8 GitHub Issue Lifecycle
-- Every TASK-NNN MUST have a corresponding GitHub issue. Create it at the START of the
-  implementation (Phase 1, alongside project planning), not retroactively after delivery.
-- Use `gh issue create --title "..." --label "..." --body "..."` to create issues via CLI.
-- Update the issue with progress comments during long-running tasks if needed.
-- Close the issue with `gh issue close N --comment "Completed in commit <hash>."` when pushed.
-- If an existing open issue matches the task being implemented, use that issue instead of creating a duplicate.
-- **Rule**: The Release Engineer checklist includes "GitHub Issue closed" — a task is NOT done until the issue is closed.
+### 12.5 Branch-First Workflow
+- ALWAYS create a named branch from clean `master` BEFORE any code changes.
+- Feature branches MUST include TASK-ID: `feature/task-030-smart-resume-reuse-m1`.
+- One branch per task. Never reuse branches across unrelated tasks.
+- After merge, delete the remote branch to keep the repo clean.

--- a/.claude/references/shared-workflows.md
+++ b/.claude/references/shared-workflows.md
@@ -1,0 +1,174 @@
+# Shared Workflows — Single Source of Truth
+
+> Referenced by CLAUDE.md and all skill files. Update HERE, not in individual files.
+> Last updated: 2026-03-11
+
+---
+
+## 1. Branch Lifecycle
+
+### Branch Naming Convention
+```
+type/short-description
+```
+
+| Type | When | Example |
+|------|------|---------|
+| `feature/` | New functionality (include TASK-ID) | `feature/task-030-smart-resume-reuse-m1` |
+| `fix/` | Bug fixes | `fix/mypy-type-error-experience-calc` |
+| `refactor/` | Code restructuring, no behavior change | `refactor/extract-db-helpers` |
+| `docs/` | Documentation only | `docs/update-readme-test-count` |
+| `test/` | Test additions/fixes only | `test/add-kb-integration-tests` |
+| `chore/` | Maintenance, deps, CI config | `chore/upgrade-playwright` |
+
+### Mandatory Steps (every code change)
+```bash
+# 1. Start from clean master
+git checkout master && git pull origin master
+
+# 2. Create branch (BEFORE any code changes)
+git checkout -b type/short-description
+
+# 3. Do work, commit with conventional messages
+git add <files>
+git commit -m "type: short summary
+
+Optional body — explain WHY, not WHAT.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+
+# 4. Push
+git push -u origin type/short-description
+
+# 5. Open PR
+gh pr create --title "type: short summary" --body "..."
+
+# 6. CI must pass (lint, test, security) before merge
+
+# 7. Squash-merge to master, delete remote branch
+```
+
+### Rules
+- One branch per task. Never reuse branches across unrelated tasks.
+- Never work directly on `master`. Never force-push to `master`.
+- Feature branches MUST include TASK-ID for traceability.
+- After merge, delete the remote branch to keep the repo clean.
+
+---
+
+## 2. GitHub Issue Lifecycle
+
+### Create (Phase 0a — before any work)
+```bash
+gh issue create \
+  --title "TASK-NNN: Short description" \
+  --label "backend,smart-reuse" \
+  --body "## Scope
+- What this issue covers
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Files
+- \`path/to/file.py\` — description"
+```
+
+### Update (during work, if long-running)
+```bash
+gh issue comment NNN --body "Progress: completed X, starting Y. No blockers."
+```
+
+### Close (Phase 14 — after merge)
+```bash
+gh issue close NNN --comment "Completed in commit $(git rev-parse --short HEAD). PR #NN merged."
+```
+
+### Rules
+- Every TASK-NNN MUST have a GitHub issue. Create at Phase 0a, close at Phase 14.
+- If an existing open issue matches the task, use it instead of creating a duplicate.
+- A task is NOT done until the issue is closed.
+
+---
+
+## 3. PR Checklist
+
+Before opening a PR, verify:
+
+- [ ] Branch created from latest `master` using naming convention (§1)
+- [ ] `ruff check .` passes (lint)
+- [ ] `mypy app.py app_state.py run.py config/ core/ db/ bot/ routes/` passes (type check)
+- [ ] `python -m pytest tests/ -v` passes (all tests)
+- [ ] New code has unit tests (coverage target: >=90% line, >=85% branch)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` if user-facing change
+- [ ] GitHub issue referenced in commit body (`Closes #NNN`)
+
+PR description MUST include:
+```markdown
+## Summary
+<1-3 bullet points>
+
+## Changes
+<bullet list of specific changes>
+
+## Test plan
+- [ ] Tests pass locally
+- [ ] Lint clean
+- [ ] Coverage meets threshold
+
+## Related issues
+Closes #NNN
+```
+
+---
+
+## 4. Scope Determination
+
+Use this decision tree at Phase 1 (Project Planning) to classify task size:
+
+```
+Is the task a single-file bugfix or typo fix?
+  YES → Small (< 50 LOC)
+  NO ↓
+
+Does the task touch ≤ 3 files with no new modules or DB changes?
+  YES → Medium (50-300 LOC)
+  NO ↓
+
+Does the task require new modules, DB tables, API endpoints, or UI components?
+  YES → Large (300+ LOC)
+```
+
+| Scope | Leadership | Design | Build | Test | Quality | Release |
+|-------|-----------|--------|-------|------|---------|---------|
+| Small | Inline PM | Inline SE | Full | Unit only | Quick scan | Inline |
+| Medium | Full PM | Full SE | Full | Full | Full audit | Full |
+| Large | Full PgM+PM | Full SE+AWS | Full | Full+Perf | Full report | Full pkg |
+
+### Role Activation by Task Type
+
+| Task Type | Roles (in order) |
+|-----------|-----------------|
+| Backend feature | PgM → PjM → PM → RA → SE → BE → UT → IT → SecE → Doc → RE |
+| Frontend feature | PgM → PjM → PM → RA → SE → FE → UT → IT → SecE → Doc → RE |
+| Full-stack feature | PgM → PjM → PM → RA → SE → BE+FE → UT → IT → SecE → Doc → RE |
+| Bugfix (small) | PjM(inline) → BE or FE → UT → Doc(inline) → RE(inline) |
+| Docs only | PjM(inline) → Doc → RE(inline) |
+| Test only | PjM(inline) → UT or IT → RE(inline) |
+
+---
+
+## 5. Traceability Matrix Rules
+
+| Rule | Enforcement |
+|------|-------------|
+| Every FR must map to ≥1 design component | System Engineer checks at Phase 4 gate |
+| Every FR must have ≥1 unit test | Unit Tester checks at Phase 10 gate |
+| Every NFR must have a validation method | Requirements Analyst checks at Phase 3 gate |
+| Every row must have all columns filled | Release Engineer checks at Phase 14 gate |
+| Zero gaps allowed for release | PR blocked until all rows are ✅ |
+
+Complete the matrix at Phase 14 using this template:
+```
+| Req ID | Title | Design Ref | Source Files | Unit Tests | Integ Tests | Docs | Security | Status |
+```

--- a/.claude/skills/role-backend-developer/SKILL.md
+++ b/.claude/skills/role-backend-developer/SKILL.md
@@ -22,6 +22,9 @@ optimized for maintainability, testability, and operational excellence.
 **From**: System Engineer (SAD, interface contracts, data model, impl plan)
 **To**: Unit Tester, Integration Tester, Frontend Developer (API contracts)
 
+> **Shared Workflows**: Branch creation, PR checklist, and commit conventions
+> are in `references/shared-workflows.md`. Follow that file for all git operations.
+
 ---
 
 ## SOP-1: Pre-Implementation

--- a/.claude/skills/role-project-manager/SKILL.md
+++ b/.claude/skills/role-project-manager/SKILL.md
@@ -21,6 +21,10 @@ control scope changes, manage risks, and ensure clean handoffs between all roles
 **From**: Program Manager (strategic alignment), Product Manager (PRD, priorities)
 **To**: All roles (coordination and sequencing)
 
+> **Shared Workflows**: Branch lifecycle, issue lifecycle, PR checklist, and scope
+> determination are defined in `references/shared-workflows.md`. Reference that
+> file for canonical rules — do not duplicate them here.
+
 ---
 
 ## SOP-1: Task Classification and Role Activation
@@ -80,8 +84,9 @@ Upon receiving a task, classify and activate the right roles:
 
 | # | Phase | Role(s) | Deliverable | Size | Depends On | Status |
 |---|-------|---------|-------------|------|------------|--------|
-| 0 | GitHub Issue | PjM | `gh issue create` with title + labels | S | — | ⬜ |
-| 1 | Program alignment | PgM | Alignment confirmation | S | 0 | ⬜ |
+| 0a| GitHub Issue | PjM | `gh issue create` with title + labels | S | — | ⬜ |
+| 0b| Branch Creation | PjM | `git checkout -b type/short-description` | S | 0a | ⬜ |
+| 1 | Program alignment | PgM | Alignment confirmation | S | 0a | ⬜ |
 | 2 | Project planning | PjM | This plan + role activation | S | 1 | ⬜ |
 | 3 | Product vision | PM | PRD + user stories | S-M | 2 | ⬜ |
 | 4 | Requirements | RA | SRS document | M | 3 | ⬜ |

--- a/.claude/skills/role-release-engineer/SKILL.md
+++ b/.claude/skills/role-release-engineer/SKILL.md
@@ -18,6 +18,10 @@ The release is complete, traceable, deployable, and rollback-ready.
 **From**: Security Engineer (audit passed), Documenter (docs complete)
 **Needs**: All source, tests, docs, security report, design docs, requirements.
 
+> **Shared Workflows**: Branch lifecycle, issue lifecycle, PR checklist, and
+> traceability rules are in `references/shared-workflows.md`. Follow that file
+> for all git, PR, and issue operations.
+
 ## Output → Handoff To
 **Produces**: Release package, manifest, traceability matrix, deploy config,
 rollback plan, delivery summary.


### PR DESCRIPTION
## Summary
- Extract shared workflows into single source of truth (`references/shared-workflows.md`)
- Add Phase 0a/0b/0c to pipeline (GitHub Issue → Branch Creation → Program Alignment)
- Unify coverage thresholds, condense lessons learned, improve readability

## Changes
- **CLAUDE.md v4.2 → v5.0**: Added Phase 0a/0b/0c to §2 pipeline table, unified coverage to >=90% line / >=85% branch in §8.6, switched role activation table to readable abbreviations (PgM/PjM/PM/RA/SE/BE/FE etc), condensed §12 from 8 to 5 sections (merged duplicates with §8), added shared-workflows references throughout
- **NEW `references/shared-workflows.md`**: Single source of truth for branch lifecycle (naming, mandatory steps, rules), GitHub issue lifecycle (create/update/close), PR checklist, scope determination decision tree, traceability matrix rules
- **role-project-manager/SKILL.md**: WBS Phase 0 split into 0a (issue) + 0b (branch), added shared-workflows reference
- **role-backend-developer/SKILL.md**: Added shared-workflows reference for git operations
- **role-release-engineer/SKILL.md**: Added shared-workflows reference for PR/issue operations

## Test plan
- [x] No code changes — documentation/governance only
- [x] All shared-workflows rules consistent with CLAUDE.md
- [x] Coverage thresholds unified across CLAUDE.md (§8.6, §9.3) and shared-workflows.md (§3)
- [x] Supersedes PR #40 (chore/enforce-branch-first-workflow)

## Related issues
Closes #40 (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)