### PR TITLE
chore: add gitignore patterns for temp output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ profile/cover_letters/
 .coverage
 htmlcov/
 .pytest_cache/
+cov_*.txt
+test_*.txt
+*_results.txt
+*_output.txt
+*_stderr.txt
 
 # Playwright
 playwright-report/


### PR DESCRIPTION
## Summary
- Add gitignore patterns to prevent temp test/coverage files from being committed
- Deleted 20 stale temp files from working directory

## Changes
- `.gitignore`: Added `cov_*.txt`, `test_*.txt`, `*_results.txt`, `*_output.txt`, `*_stderr.txt`

## Test plan
- [x] No code changes
- [x] Verified `git status` shows clean after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)