### PR TITLE
fix: add missing static/js/api.js — resolves blank page on load

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,0 +1,27 @@
+/* ═══════════════════════════════════════════════════════════════
+   API — Shared fetch wrapper and HTML utilities
+   ═══════════════════════════════════════════════════════════════ */
+import { escHtml } from './helpers.js';
+
+/**
+ * Fetch wrapper that parses JSON responses and throws on non-OK status.
+ * Auth headers are injected by auth.js (patches window.fetch).
+ * @param {string} url
+ * @param {RequestInit} [opts]
+ * @returns {Promise<any>}
+ */
+export async function apiFetch(url, opts = {}) {
+  const res = await fetch(url, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`${res.status}: ${text}`);
+  }
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) {
+    return res.json();
+  }
+  return res;
+}
+
+// Re-export escHtml for modules that import both from api.js
+export { escHtml };


### PR DESCRIPTION
## Summary
The app shows a blank/stuck page because `resumes.js` imports from `./api.js` which doesn't exist (404). This breaks the entire ES module tree since ES modules fail-fast on import errors.

## Root cause
`resumes.js` line 6: `import { apiFetch, escHtml } from './api.js';` — the file was never created during the resume versioning feature (TASK-018).

## Fix
Create `static/js/api.js` with:
- `apiFetch()` — fetch wrapper that parses JSON and throws on non-OK status (auth handled by `auth.js` global fetch patch)
- Re-export `escHtml` from `helpers.js`

## Test plan
- [ ] CI passes
- [ ] App loads without blank page
- [ ] Resume Library tab works (uses apiFetch)
- [ ] Knowledge Base tab visible in navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)