### PR TITLE
fix: use 7z for Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
           VERSION=$(python -c "import tomllib; print(tomllib.load(open('../pyproject.toml','rb'))['project']['version'])")
           if [ "$RUNNER_OS" = "Windows" ]; then
             PLATFORM="win-x64"
+            7z a "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           elif [ "$RUNNER_OS" = "macOS" ]; then
             PLATFORM="mac-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           else
             PLATFORM="linux-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           fi
-          zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Windows CI runners don't have `zip` — use `7z` (pre-installed) instead
- Fixes v2.4.0 release build failure on Windows

## Test plan
- [ ] CI passes
- [ ] Re-tag v2.4.0 after merge to master triggers successful Windows build

🤖 Generated with [Claude Code](https://claude.com/claude-code)