### PR TITLE
fix: Windows release build (v2.4.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
           VERSION=$(python -c "import tomllib; print(tomllib.load(open('../pyproject.toml','rb'))['project']['version'])")
           if [ "$RUNNER_OS" = "Windows" ]; then
             PLATFORM="win-x64"
+            7z a "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           elif [ "$RUNNER_OS" = "macOS" ]; then
             PLATFORM="mac-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           else
             PLATFORM="linux-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           fi
-          zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autoapply"
-version = "2.3.3"
+version = "2.4.0"
 description = "Smart job application automation bot with desktop dashboard"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Fix Windows release build: use `7z` instead of `zip` (not available on windows-latest)
- Enables re-tag of v2.4.0 with working Windows build

## Test plan
- [ ] CI passes
- [ ] Re-tag v2.4.0 triggers successful builds on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)