### PR TITLE
fix: default to GUI mode in PyInstaller builds

### DIFF
--- a/run.py
+++ b/run.py
@@ -145,7 +145,10 @@ def main() -> None:
     data_dir = _setup_data_dirs()
     _configure_logging(data_dir)
 
-    if args.gui:
+    # Default to GUI mode when running as frozen PyInstaller bundle
+    is_frozen = getattr(sys, "frozen", False)
+
+    if args.gui or is_frozen:
         # PyWebView desktop mode — Flask starts in a daemon thread
         from shell import launch_gui
 


### PR DESCRIPTION
## Summary
- PyInstaller exe launched in headless mode (no window) because `--gui` flag wasn't passed
- Now auto-detects `sys.frozen` (PyInstaller environment) and defaults to GUI mode

## Test plan
- [ ] CI passes
- [ ] `python run.py` still runs in headless mode (no regression)
- [ ] `python run.py --gui` still works
- [ ] PyInstaller exe opens GUI window

🤖 Generated with [Claude Code](https://claude.com/claude-code)