### PR TITLE
release: v2.4.1 — fix exe not launching GUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autoapply"
-version = "2.4.0"
+version = "2.4.1"
 description = "Smart job application automation bot with desktop dashboard"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Fix: exe defaulting to headless mode (no window) — now auto-detects PyInstaller and launches GUI
- Fix: Windows release build using `7z` instead of missing `zip`
- Version bump to 2.4.1

## Test plan
- [ ] CI passes
- [ ] Merge to master, tag v2.4.1, verify all 3 platform builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)