### PR TITLE
release: v2.4.1 — fix exe GUI + Windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
           VERSION=$(python -c "import tomllib; print(tomllib.load(open('../pyproject.toml','rb'))['project']['version'])")
           if [ "$RUNNER_OS" = "Windows" ]; then
             PLATFORM="win-x64"
+            7z a "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           elif [ "$RUNNER_OS" = "macOS" ]; then
             PLATFORM="mac-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           else
             PLATFORM="linux-x64"
+            zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
           fi
-          zip -r "AutoApply-${VERSION}-${PLATFORM}.zip" AutoApply/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autoapply"
-version = "2.4.0"
+version = "2.4.1"
 description = "Smart job application automation bot with desktop dashboard"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autoapply"
-version = "2.3.3"
+version = "2.4.0"
 description = "Smart job application automation bot with desktop dashboard"
 requires-python = ">=3.11"
 dependencies = [

--- a/run.py
+++ b/run.py
@@ -145,7 +145,10 @@ def main() -> None:
     data_dir = _setup_data_dirs()
     _configure_logging(data_dir)
 
-    if args.gui:
+    # Default to GUI mode when running as frozen PyInstaller bundle
+    is_frozen = getattr(sys, "frozen", False)
+
+    if args.gui or is_frozen:
         # PyWebView desktop mode — Flask starts in a daemon thread
         from shell import launch_gui
 


### PR DESCRIPTION
## Summary
- Fix: exe now defaults to GUI mode when running as PyInstaller bundle (was headless, no window)
- Fix: Windows release build uses `7z` instead of missing `zip` command
- Version bump to 2.4.1

## Test plan
- [ ] CI passes
- [ ] Tag v2.4.1 triggers successful builds on all 3 platforms
- [ ] Windows exe opens GUI window

🤖 Generated with [Claude Code](https://claude.com/claude-code)