### PR TITLE
fix: detect external LinkedIn applications early to avoid freeze

### DIFF
--- a/bot/apply/linkedin.py
+++ b/bot/apply/linkedin.py
@@ -19,14 +19,36 @@ class LinkedInApplier(BaseApplier):
         self, job, resume_pdf_path, cover_letter_text, profile
     ) -> ApplyResult:
         logger.info("LinkedIn: applying to %s at %s", job.raw.title, job.raw.company)
-        self._safe_goto(job.raw.apply_url)
-        self._random_pause(1, 3)
+
+        # Skip navigation if _apply_to_job already navigated to this page
+        if not self.page.url.startswith(job.raw.apply_url.rstrip("/")):
+            self._safe_goto(job.raw.apply_url)
+            self._random_pause(1, 3)
 
         if self._detect_captcha():
             return ApplyResult(
                 success=False, captcha_detected=True,
                 error_message="CAPTCHA detected",
             )
+
+        # Detect external application links early — skip without waiting
+        external_btn = self.page.query_selector(
+            "button[aria-label*='Apply now'], "
+            "a.jobs-apply-button[href]:not([href*='linkedin.com']), "
+            "button.jobs-apply-button span.artdeco-button__text"
+        )
+        if external_btn:
+            btn_text = external_btn.inner_text().strip().lower()
+            # "Easy Apply" = native, anything else ("Apply", "Apply now") = external
+            if "easy apply" not in btn_text:
+                logger.info(
+                    "LinkedIn: external application detected ('%s') for %s — skipping",
+                    btn_text, job.raw.title,
+                )
+                return ApplyResult(
+                    success=False, manual_required=True,
+                    error_message=f"External application ('{btn_text}') — not Easy Apply",
+                )
 
         # Find and click Easy Apply button with explicit wait
         easy_apply_btn = self._wait_and_query(

--- a/tests/test_appliers_coverage.py
+++ b/tests/test_appliers_coverage.py
@@ -62,6 +62,13 @@ def _make_scored_job(apply_url, platform):
                      pass_filter=True, skip_reason=None)
 
 
+def _make_easy_apply_text_btn():
+    """Create a mock for the artdeco-button__text element that says 'Easy Apply'."""
+    btn = MagicMock()
+    btn.inner_text.return_value = "Easy Apply"
+    return btn
+
+
 def _make_page(url="https://example.com"):
     page = MagicMock()
     page.url = url
@@ -133,6 +140,9 @@ class TestLinkedInUploadResumeException:
         """Test multi-step modal with Next button before Submit."""
         page = _make_page("https://www.linkedin.com/jobs/view/123/")
         easy_btn = MagicMock()
+        # Mock for external button detection — return "Easy Apply" text
+        easy_apply_text_btn = MagicMock()
+        easy_apply_text_btn.inner_text.return_value = "  Easy Apply  "
         submit_btn = MagicMock()
         submit_btn.is_visible.return_value = True
         next_btn = MagicMock()
@@ -143,6 +153,8 @@ class TestLinkedInUploadResumeException:
 
         def qs(selector):
             call_count["n"] += 1
+            if "artdeco-button__text" in selector:
+                return easy_apply_text_btn
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 return easy_btn
             if "Submit" in selector:
@@ -167,15 +179,19 @@ class TestLinkedInUploadResumeException:
         """Test CAPTCHA detected inside modal step."""
         page = _make_page("https://www.linkedin.com/jobs/view/123/")
         easy_btn = MagicMock()
+        easy_apply_text_btn = MagicMock()
+        easy_apply_text_btn.inner_text.return_value = "Easy Apply"
 
         step = {"n": 0}
 
         def qs(selector):
             step["n"] += 1
-            if step["n"] <= 2 and ("Easy Apply" in selector or "jobs-apply-button" in selector):
+            if "artdeco-button__text" in selector:
+                return easy_apply_text_btn
+            if step["n"] <= 3 and ("Easy Apply" in selector or "jobs-apply-button" in selector):
                 return easy_btn
             # After clicking Easy Apply, CAPTCHA appears
-            if step["n"] > 2:
+            if step["n"] > 3:
                 return MagicMock()  # CAPTCHA element
             return None
 
@@ -189,7 +205,8 @@ class TestLinkedInUploadResumeException:
     @patch("bot.apply.base.time.sleep")
     def test_exception_returns_failure(self, _sleep):
         """Lines 45-47: exception in _do_apply returns ApplyResult."""
-        page = _make_page("https://www.linkedin.com/jobs/view/123/")
+        # Use a different page URL so navigation is attempted
+        page = _make_page("https://www.linkedin.com/feed/")
         page.goto.side_effect = Exception("Network error")
         applier = LinkedInApplier(page)
         job = _make_scored_job("https://www.linkedin.com/jobs/view/123/", "linkedin")
@@ -210,6 +227,26 @@ class TestLinkedInUploadResumeException:
         assert "Easy Apply" in result.error_message
 
     @patch("bot.apply.base.time.sleep")
+    def test_external_application_detected(self, _sleep):
+        """External application button ('Apply') detected — skip immediately."""
+        page = _make_page("https://www.linkedin.com/jobs/view/123/")
+        external_btn = MagicMock()
+        external_btn.inner_text.return_value = "Apply"
+
+        def qs(selector):
+            if "artdeco-button__text" in selector:
+                return external_btn
+            return None
+
+        page.query_selector.side_effect = qs
+        applier = LinkedInApplier(page)
+        job = _make_scored_job("https://www.linkedin.com/jobs/view/123/", "linkedin")
+        result = applier.apply(job, None, "", _make_profile())
+        assert result.success is False
+        assert result.manual_required is True
+        assert "External application" in result.error_message
+
+    @patch("bot.apply.base.time.sleep")
     def test_submit_with_confirmation_close(self, _sleep):
         """Lines 117-126: submit found, confirmation modal, close button clicked."""
         page = _make_page("https://www.linkedin.com/jobs/view/123/")
@@ -220,6 +257,8 @@ class TestLinkedInUploadResumeException:
         close_btn = MagicMock()
 
         def qs(selector):
+            if "artdeco-button__text" in selector:
+                return _make_easy_apply_text_btn()
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 return easy_btn
             if "captcha" in selector or "recaptcha" in selector or "sitekey" in selector:
@@ -245,6 +284,8 @@ class TestLinkedInUploadResumeException:
         easy_btn = MagicMock()
 
         def qs(selector):
+            if "artdeco-button__text" in selector:
+                return _make_easy_apply_text_btn()
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 return easy_btn
             if "captcha" in selector or "recaptcha" in selector or "sitekey" in selector:
@@ -318,6 +359,8 @@ class TestLinkedInUploadResumeException:
         fi = MagicMock()
 
         def qs(selector):
+            if "artdeco-button__text" in selector:
+                return _make_easy_apply_text_btn()
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 return easy_btn
             if "captcha" in selector or "recaptcha" in selector or "sitekey" in selector:
@@ -345,6 +388,8 @@ class TestLinkedInUploadResumeException:
         loop_entered = {"v": False}
 
         def qs(selector):
+            if "artdeco-button__text" in selector:
+                return _make_easy_apply_text_btn()
             # Easy Apply button found
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 if not loop_entered["v"]:
@@ -382,6 +427,8 @@ class TestLinkedInUploadResumeException:
         step = {"n": 0}
 
         def qs(selector):
+            if "artdeco-button__text" in selector:
+                return _make_easy_apply_text_btn()
             if "Easy Apply" in selector or "jobs-apply-button" in selector:
                 return easy_btn
             if "captcha" in selector or "recaptcha" in selector or "sitekey" in selector:


### PR DESCRIPTION
## Summary
- Bot froze for ~68s on LinkedIn jobs with external application links ("Apply" instead of "Easy Apply")
- Now detects external application button text immediately and skips without waiting
- Skips redundant page navigation when already on the correct URL
- Added test for external application detection

## Changes
- `bot/apply/linkedin.py`: Early external button detection, skip redundant navigation
- `tests/test_appliers_coverage.py`: Updated mocks for new detection logic, added external app test

## Test plan
- [ ] CI passes (lint, test, security)
- [ ] External LinkedIn jobs are skipped instantly with `manual_required=True`
- [ ] Easy Apply jobs still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)